### PR TITLE
Remove default `value`

### DIFF
--- a/src/svelteSegmentedInput.svelte
+++ b/src/svelteSegmentedInput.svelte
@@ -4,7 +4,7 @@
     export let length
     let els = []
     let values = []
-    export let value = 'typing'
+    export let value = ''
     export let style = {}
 
     let varNames = Object.keys(style)
@@ -17,7 +17,7 @@
     
     $: {
         (() => {
-            if (values.length != getTotalLength(length) || values.includes(null)) return value = 'typing'
+            if (values.length != getTotalLength(length) || values.includes(null)) return value = ''
             value = 0
             values.forEach((digit, index) => {
                 value += digit * (10 ** (getTotalLength(length) - index - 1))


### PR DESCRIPTION
There's no reason to set it to `typing` and it's also easier to check for empty values this way